### PR TITLE
fix: use request tokenAmount to validate min/max token amounts in updateParticipation

### DIFF
--- a/src/Launch.sol
+++ b/src/Launch.sol
@@ -362,14 +362,14 @@ contract Launch is
             // Transfer payment currency from contract to user
             IERC20(request.currency).safeTransfer(msg.sender, refundCurrencyAmount);
         } else if (newCurrencyAmount > prevInfo.currencyAmount) {
-            // Calculate additional payment amount
-            uint256 additionalCurrencyAmount = newCurrencyAmount - prevInfo.currencyAmount;
             // Validate user new requested token amount is within launch group user allocation limits
-            if (userTokenAmount + additionalCurrencyAmount > settings.maxTokenAmountPerUser) {
+            if (request.tokenAmount > settings.maxTokenAmountPerUser) {
                 revert MaxUserTokenAllocationReached(
                     request.launchGroupId, request.userId, userTokenAmount, request.tokenAmount
                 );
             }
+            // Calculate additional payment amount
+            uint256 additionalCurrencyAmount = newCurrencyAmount - prevInfo.currencyAmount;
             // Update total tokens requested for user for launch group
             userTokens.set(request.userId, userTokenAmount + additionalCurrencyAmount);
             // Transfer payment currency from user to contract

--- a/src/Launch.sol
+++ b/src/Launch.sol
@@ -349,14 +349,14 @@ contract Launch is
         (, uint256 userTokenAmount) = userTokens.tryGet(request.userId);
         // If new requested token amount is less than old amount, handle refund
         if (prevInfo.currencyAmount > newCurrencyAmount) {
-            // Calculate refund amount
-            uint256 refundCurrencyAmount = prevInfo.currencyAmount - newCurrencyAmount;
             // Validate user new requested token amount is greater than min token amount per user
-            if (userTokenAmount - refundCurrencyAmount < settings.minTokenAmountPerUser) {
+            if (request.tokenAmount < settings.minTokenAmountPerUser) {
                 revert MinUserTokenAllocationNotReached(
                     request.launchGroupId, request.userId, userTokenAmount, request.tokenAmount
                 );
             }
+            // Calculate refund amount
+            uint256 refundCurrencyAmount = prevInfo.currencyAmount - newCurrencyAmount;
             // Update total tokens requested for user for launch group
             userTokens.set(request.userId, userTokenAmount - refundCurrencyAmount);
             // Transfer payment currency from contract to user


### PR DESCRIPTION
Description
----
Fix validation in `updateParticipation` to use  request `tokenAmount` to validate `minTokenAmountPerUser` and `maxTokenAmountPerUser`.

Issue
---- 
https://audits.sherlock.xyz/contests/498/voting/231?dashboard_id=2808a45ed4bd06b969526db15b2b7f7d