### PR TITLE
fix: set user tokens to the request tokenAmount in updateParticipation

### DIFF
--- a/src/Launch.sol
+++ b/src/Launch.sol
@@ -357,8 +357,6 @@ contract Launch is
                     request.launchGroupId, request.userId, userTokenAmount, request.tokenAmount
                 );
             }
-            // Update total tokens requested for user for launch group
-            userTokens.set(request.userId, userTokenAmount - refundCurrencyAmount);
             // Transfer payment currency from contract to user
             IERC20(request.currency).safeTransfer(msg.sender, refundCurrencyAmount);
         } else if (newCurrencyAmount > prevInfo.currencyAmount) {
@@ -370,12 +368,11 @@ contract Launch is
                     request.launchGroupId, request.userId, userTokenAmount, request.tokenAmount
                 );
             }
-            // Update total tokens requested for user for launch group
-            userTokens.set(request.userId, userTokenAmount + additionalCurrencyAmount);
             // Transfer payment currency from user to contract
             IERC20(request.currency).safeTransferFrom(msg.sender, address(this), additionalCurrencyAmount);
         }
-
+        // Update total tokens requested for user for launch group
+        userTokens.set(request.userId, request.tokenAmount);
         // Set participation details for user
         newInfo.currencyAmount = newCurrencyAmount;
         newInfo.currency = request.currency;

--- a/test/Launch.UpdateParticipation.t.sol
+++ b/test/Launch.UpdateParticipation.t.sol
@@ -75,6 +75,9 @@ contract LaunchUpdateParticipationTest is Test, Launch, LaunchTestBase {
         // Verify total unique participants by launch group
         assertEq(launch.getNumUniqueParticipantsByLaunchGroup(testLaunchGroupId), 1);
 
+        // Verify user tokens
+        assertEq(launch.getUserTokensByLaunchGroup(testLaunchGroupId, testUserId), updateRequest.tokenAmount);
+
         vm.stopPrank();
     }
 
@@ -112,6 +115,9 @@ contract LaunchUpdateParticipationTest is Test, Launch, LaunchTestBase {
 
         // Verify total unique participants by launch group
         assertEq(launch.getNumUniqueParticipantsByLaunchGroup(testLaunchGroupId), 1);
+
+        // Verify user tokens
+        assertEq(launch.getUserTokensByLaunchGroup(testLaunchGroupId, testUserId), updateRequest.tokenAmount);
 
         vm.stopPrank();
     }


### PR DESCRIPTION
Description
----
Fix the logic in `updateParticipation` to set user tokens for the launch group and make the request `tokenAmount`. 

Note the suggested mitigation involves calculating the token delta using it to determine the new value:

> Mitigation
> Use the correct value/variable which should be the difference between the previous tokenAmount and the new requested tokenAmount.
> ```
> - userTokens.set(request.userId, userTokenAmount - refundCurrencyAmount);  
> + uint256 tokenDelta = prevInfo.tokenAmount - request.tokenAmount;  
> + (userTokens.set(request.userId, userTokenAmount - tokenDelta);  
>  ```

Since `updateParticipation` should fully replace the users' previous participation in the launch group, I think the token delta calculation is not necessary and the user tokens for the launch group can be set to the request `tokenAmount`.

Issue
---- 
https://audits.sherlock.xyz/contests/498/voting/231?dashboard_id=2808a45ed4bd06b969526db15b2b7f7d

