### PR TITLE
fix: remove redundant token amount subtraction in cancelParticipation

### DIFF
--- a/src/Launch.sol
+++ b/src/Launch.sol
@@ -333,6 +333,10 @@ contract Launch is
         if (settings.finalizesAtParticipation || prevInfo.isFinalized) {
             revert ParticipationUpdatesNotAllowed(request.launchGroupId, request.prevLaunchParticipationId);
         }
+        // Do not allow updates to cancelled participation
+        if (prevInfo.tokenAmount == 0 || prevInfo.currencyAmount == 0) {
+            revert ParticipationUpdatesNotAllowed(request.launchGroupId, request.prevLaunchParticipationId);
+        }
 
         // Validate participation exists and user, requested currency match
         ParticipationInfo storage newInfo = launchGroupParticipations[request.newLaunchParticipationId];
@@ -422,6 +426,10 @@ contract Launch is
             revert ParticipationUpdatesNotAllowed(request.launchGroupId, request.launchParticipationId);
         }
         if (info.isFinalized) {
+            revert ParticipationUpdatesNotAllowed(request.launchGroupId, request.launchParticipationId);
+        }
+        // Do not allow updates to cancelled participation
+        if (info.tokenAmount == 0 || info.currencyAmount == 0) {
             revert ParticipationUpdatesNotAllowed(request.launchGroupId, request.launchParticipationId);
         }
 

--- a/src/Launch.sol
+++ b/src/Launch.sol
@@ -430,21 +430,8 @@ contract Launch is
             revert UserIdMismatch(info.userId, request.userId);
         }
 
-        // Get total tokens requested for user for launch group
-        EnumerableMap.Bytes32ToUintMap storage userTokens = _userTokensByLaunchGroup[request.launchGroupId];
-        (, uint256 userTokenAmount) = userTokens.tryGet(request.userId);
-        if (userTokenAmount - info.tokenAmount == 0) {
-            // If total tokens requested for user is the same as the cancelled participation, remove user from launch group
-            userTokens.remove(request.userId);
-        } else if (userTokenAmount - info.tokenAmount < settings.minTokenAmountPerUser) {
-            // Total tokens requested for user after cancellation must be greater than min token amount per user
-            revert MinUserTokenAllocationNotReached(
-                request.launchGroupId, request.userId, userTokenAmount, info.tokenAmount
-            );
-        } else {
-            // Subtract cancelled participation token amount from total tokens requested for user
-            userTokens.set(request.userId, userTokenAmount - info.tokenAmount);
-        }
+        // Remove user requested token amount from launch group
+        _userTokensByLaunchGroup[request.launchGroupId].remove(request.userId);
 
         // Transfer payment currency from contract to user
         uint256 refundCurrencyAmount = info.currencyAmount;

--- a/test/Launch.CancelParticipation.t.sol
+++ b/test/Launch.CancelParticipation.t.sol
@@ -41,7 +41,6 @@ contract LaunchCancelParticipationTest is Test, Launch, LaunchTestBase {
         ParticipationInfo memory info = launch.getParticipationInfo(cancelRequest.launchParticipationId);
         assertEq(info.tokenAmount, 1000 * 10 ** 18);
         assertEq(info.currencyAmount, 1000 * 10 ** 18);
-        uint256 initialUserTokenAmount = launch.getUserTokensByLaunchGroup(testLaunchGroupId, testUserId);
         uint256 startingBalance = currency.balanceOf(user1);
 
         vm.startPrank(user1);
@@ -71,7 +70,7 @@ contract LaunchCancelParticipationTest is Test, Launch, LaunchTestBase {
 
         // Verify user tokens
         uint256 userTokenAmount = launch.getUserTokensByLaunchGroup(testLaunchGroupId, testUserId);
-        assertEq(userTokenAmount, initialUserTokenAmount - info.tokenAmount);
+        assertEq(userTokenAmount, 0);
 
         // Verify user ID is no longer in the launch group
         assertEq(launch.getLaunchGroupParticipantUserIds(testLaunchGroupId).length, 0);

--- a/test/Launch.CancelParticipation.t.sol
+++ b/test/Launch.CancelParticipation.t.sol
@@ -233,6 +233,23 @@ contract LaunchCancelParticipationTest is Test, Launch, LaunchTestBase {
         launch.cancelParticipation(request, signature);
     }
 
+    function test_RevertIf_CancelParticipation_ParticipationUpdatesNotAllowedIfCancelled() public {
+        // Prepare cancel participation request
+        CancelParticipationRequest memory request = _createCancelParticipationRequest();
+        bytes memory signature = _signRequest(abi.encode(request));
+        vm.startPrank(user1);
+
+        // Cancel participation
+        launch.cancelParticipation(request, signature);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ParticipationUpdatesNotAllowed.selector, request.launchGroupId, request.launchParticipationId
+            )
+        );
+        // Cancel participation
+        launch.cancelParticipation(request, signature);
+    }
+
     function test_RevertIf_CancelParticipation_InvalidCancelParticipationRequestUserId() public {
         // Prepare cancel participation request
         CancelParticipationRequest memory request = _createCancelParticipationRequest();

--- a/test/Launch.UpdateParticipation.t.sol
+++ b/test/Launch.UpdateParticipation.t.sol
@@ -7,6 +7,7 @@ import {Test} from "forge-std/Test.sol";
 import {LaunchTestBase} from "./LaunchTestBase.t.sol";
 import {Launch} from "../src/Launch.sol";
 import {
+    CancelParticipationRequest,
     LaunchGroupSettings,
     LaunchGroupStatus,
     ParticipationRequest,
@@ -290,6 +291,26 @@ contract LaunchUpdateParticipationTest is Test, Launch, LaunchTestBase {
         vm.startPrank(user1);
         vm.expectRevert(
             abi.encodeWithSelector(ParticipationUpdatesNotAllowed.selector, launchGroupId, testLaunchParticipationId)
+        );
+        // Update participation
+        launch.updateParticipation(updateRequest, updateSignature);
+    }
+
+    function test_RevertIf_UpdateParticipation_ParticipationUpdatesNotAllowedIfCancelled() public {
+        // Cancel participation
+        CancelParticipationRequest memory cancelRequest = _createCancelParticipationRequest();
+        bytes memory cancelSignature = _signRequest(abi.encode(cancelRequest));
+        vm.startPrank(user1);
+        launch.cancelParticipation(cancelRequest, cancelSignature);
+
+        // Prepare update participation request
+        UpdateParticipationRequest memory updateRequest = _createUpdateParticipationRequest(2000);
+        bytes memory updateSignature = _signRequest(abi.encode(updateRequest));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ParticipationUpdatesNotAllowed.selector, testLaunchGroupId, testLaunchParticipationId
+            )
         );
         // Update participation
         launch.updateParticipation(updateRequest, updateSignature);


### PR DESCRIPTION
Description
---
Remove redundant token amount subtraction in `cancelParticipation`. Add additional checks to prevent updates to cancelled participations.

`userTokens` per user and launch group includes the amount from participation `info.tokenAmount` by design, this change zeros out this value on `cancelParticipation`. 


Issues
--- 
https://github.com/sherlock-audit/2025-02-rova-judging/issues/685
https://github.com/sherlock-audit/2025-02-rova-judging/issues/688