### PR TITLE
chore: lock pragma version to 0.8.22

### DIFF
--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.22;
+pragma solidity 0.8.22;
 
 import {Upgrades} from "@openzeppelin-foundry-upgrades/Upgrades.sol";
 import {Script, console} from "forge-std/Script.sol";

--- a/src/Launch.sol
+++ b/src/Launch.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.8.22;
+pragma solidity 0.8.22;
 
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {AccessControlEnumerableUpgradeable} from

--- a/src/Types.sol
+++ b/src/Types.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.8.22;
+pragma solidity 0.8.22;
 
 /// @notice The status of a launch group.
 enum LaunchGroupStatus {

--- a/test/Launch.BatchRefund.t.sol
+++ b/test/Launch.BatchRefund.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.8.22;
+pragma solidity 0.8.22;
 
 import {IAccessControl} from "@openzeppelin/contracts/access/IAccessControl.sol";
 import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";

--- a/test/Launch.CancelParticipation.t.sol
+++ b/test/Launch.CancelParticipation.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.8.22;
+pragma solidity 0.8.22;
 
 import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
 import {Test} from "forge-std/Test.sol";

--- a/test/Launch.ClaimRefund.t.sol
+++ b/test/Launch.ClaimRefund.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.8.22;
+pragma solidity 0.8.22;
 
 import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
 import {Test} from "forge-std/Test.sol";

--- a/test/Launch.FinalizeWinners.t.sol
+++ b/test/Launch.FinalizeWinners.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.8.22;
+pragma solidity 0.8.22;
 
 import {IAccessControl} from "@openzeppelin/contracts/access/IAccessControl.sol";
 import {Test} from "forge-std/Test.sol";

--- a/test/Launch.Initialize.t.sol
+++ b/test/Launch.Initialize.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.8.22;
+pragma solidity 0.8.22;
 
 import {UnsafeUpgrades} from "@openzeppelin-foundry-upgrades/Upgrades.sol";
 import {Test} from "forge-std/Test.sol";

--- a/test/Launch.Participate.t.sol
+++ b/test/Launch.Participate.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.8.22;
+pragma solidity 0.8.22;
 
 import {IERC20Errors} from "@openzeppelin/contracts/interfaces/draft-IERC6093.sol";
 import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";

--- a/test/Launch.Setters.t.sol
+++ b/test/Launch.Setters.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.8.22;
+pragma solidity 0.8.22;
 
 import {IAccessControl} from "@openzeppelin/contracts/access/IAccessControl.sol";
 import {Test} from "forge-std/Test.sol";

--- a/test/Launch.UpdateParticipation.t.sol
+++ b/test/Launch.UpdateParticipation.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.8.22;
+pragma solidity 0.8.22;
 
 import {IERC20Errors} from "@openzeppelin/contracts/interfaces/draft-IERC6093.sol";
 import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";

--- a/test/Launch.Withdraw.t.sol
+++ b/test/Launch.Withdraw.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.8.22;
+pragma solidity 0.8.22;
 
 import {IAccessControl} from "@openzeppelin/contracts/access/IAccessControl.sol";
 import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";

--- a/test/LaunchTestBase.t.sol
+++ b/test/LaunchTestBase.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.8.22;
+pragma solidity 0.8.22;
 
 import {UnsafeUpgrades} from "@openzeppelin-foundry-upgrades/Upgrades.sol";
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";


### PR DESCRIPTION
Description
---
Lock pragma version to 0.8.22

Issues
--- 
https://github.com/sherlock-audit/2025-02-rova-judging/issues/698
https://github.com/sherlock-audit/2025-02-rova-judging/issues/680