### PR TITLE
fix: move state update to after erc20 transfer in cancelParticipation

### DIFF
--- a/src/Launch.sol
+++ b/src/Launch.sol
@@ -445,12 +445,12 @@ contract Launch is
             revert UserIdMismatch(info.userId, request.userId);
         }
 
-        // Remove user requested token amount from launch group
-        _userTokensByLaunchGroup[request.launchGroupId].remove(request.userId);
-
         // Transfer payment currency from contract to user
         uint256 refundCurrencyAmount = info.currencyAmount;
         IERC20(info.currency).safeTransfer(info.userAddress, refundCurrencyAmount);
+
+        // Remove user requested token amount from launch group
+        _userTokensByLaunchGroup[request.launchGroupId].remove(request.userId);
 
         // Reset participation info
         info.tokenAmount = 0;


### PR DESCRIPTION
Description
---
Move state update to after erc20 transfer in `cancelParticipation`


Issues
--- 
https://github.com/sherlock-audit/2025-02-rova-judging/issues/675