### PR TITLE
chore: add token decimals and launchId validation in initialize

### DIFF
--- a/src/Launch.sol
+++ b/src/Launch.sol
@@ -196,6 +196,14 @@ contract Launch is
         if (_initialAdmin == address(0) || _withdrawalAddress == address(0)) {
             revert InvalidRequest();
         }
+        // Validate token decimals are less than or equal to 18
+        if (_tokenDecimals > 18) {
+            revert InvalidRequest();
+        }
+        // Validate launch ID is not zero
+        if (_launchId == bytes32(0)) {
+            revert InvalidRequest();
+        }
 
         // Grant initial admin default admin, manager, operator, and signer roles
         _grantRole(DEFAULT_ADMIN_ROLE, _initialAdmin);

--- a/test/Launch.Initialize.t.sol
+++ b/test/Launch.Initialize.t.sol
@@ -9,7 +9,7 @@ import {Launch} from "../src/Launch.sol";
 contract LaunchInitializeTest is Test, Launch, LaunchTestBase {
     function test_Initialize() public {
         vm.expectEmit(true, true, true, true);
-        emit Initialized(admin.addr, testWithdrawalAddress, testLaunchId, 18);
+        emit Initialized(admin.addr, testWithdrawalAddress, testLaunchId, testTokenDecimals);
 
         // Initialize launch
         _initializeLaunch(admin.addr, testWithdrawalAddress);
@@ -23,5 +23,49 @@ contract LaunchInitializeTest is Test, Launch, LaunchTestBase {
         assertTrue(launch.hasRole(launch.SIGNER_ROLE(), admin.addr));
         assertTrue(launch.hasRole(launch.WITHDRAWAL_ROLE(), testWithdrawalAddress));
         assertEq(launch.getRoleAdmin(launch.WITHDRAWAL_ROLE()), launch.WITHDRAWAL_ROLE());
+    }
+
+    function test_RevertIf_Initialize_InvalidAdmin() public {
+        address launchAddress = address(new Launch());
+        vm.expectRevert();
+        UnsafeUpgrades.deployTransparentProxy(
+            launchAddress,
+            admin.addr,
+            abi.encodeWithSelector(
+                Launch.initialize.selector, testWithdrawalAddress, testLaunchId, address(0), testTokenDecimals
+            )
+        );
+    }
+
+    function test_RevertIf_Initialize_InvalidWithdrawalAddress() public {
+        address launchAddress = address(new Launch());
+        vm.expectRevert();
+        UnsafeUpgrades.deployTransparentProxy(
+            launchAddress,
+            admin.addr,
+            abi.encodeWithSelector(Launch.initialize.selector, address(0), testLaunchId, admin.addr, testTokenDecimals)
+        );
+    }
+
+    function test_RevertIf_Initialize_InvalidTokenDecimals() public {
+        address launchAddress = address(new Launch());
+        vm.expectRevert();
+        UnsafeUpgrades.deployTransparentProxy(
+            launchAddress,
+            admin.addr,
+            abi.encodeWithSelector(Launch.initialize.selector, testWithdrawalAddress, testLaunchId, admin.addr, 19)
+        );
+    }
+
+    function test_RevertIf_Initialize_InvalidLaunchId() public {
+        address launchAddress = address(new Launch());
+        vm.expectRevert();
+        UnsafeUpgrades.deployTransparentProxy(
+            launchAddress,
+            admin.addr,
+            abi.encodeWithSelector(
+                Launch.initialize.selector, testWithdrawalAddress, bytes32(0), admin.addr, testTokenDecimals
+            )
+        );
     }
 }

--- a/test/LaunchTestBase.t.sol
+++ b/test/LaunchTestBase.t.sol
@@ -44,6 +44,8 @@ abstract contract LaunchTestBase is Test, Launch {
     bytes32 public testLaunchParticipationId = "cm6o2sldi00003b74facm5z9n";
     bytes32 public testUserId = "cm6o2tm1300003b74dsss1s7q";
 
+    uint8 public testTokenDecimals = 18;
+
     function _setUpLaunch() public {
         vm.startPrank(admin.addr);
 
@@ -183,7 +185,9 @@ abstract contract LaunchTestBase is Test, Launch {
         address proxyAddress = UnsafeUpgrades.deployTransparentProxy(
             address(new Launch()),
             adminAddress,
-            abi.encodeWithSelector(Launch.initialize.selector, withdrawalAddress, testLaunchId, adminAddress, 18)
+            abi.encodeWithSelector(
+                Launch.initialize.selector, withdrawalAddress, testLaunchId, adminAddress, testTokenDecimals
+            )
         );
         launch = Launch(proxyAddress);
     }


### PR DESCRIPTION
Description
---
Add token decimals and launchId validation in `initialize`


Issues
--- 
https://github.com/sherlock-audit/2025-02-rova-judging/issues/701
https://github.com/sherlock-audit/2025-02-rova-judging/issues/682